### PR TITLE
fix: use res.locals.email to prevent crash on delete

### DIFF
--- a/src/api/controllers/editionController.ts
+++ b/src/api/controllers/editionController.ts
@@ -142,7 +142,7 @@ export const deleteEdition = asyncErrorHandler(async (req, res, next) => {
     return next(error);
   }
 
-  console.log("Edition deleted", edition, "by user", req.body.email);
+  console.log("Edition deleted", edition, "by user", res.locals?.email);
 
   res.status(StatusCode.OK).json({
     status: "success",


### PR DESCRIPTION

What was wrong: Inside the deleteEdition controller, there was a line of code trying to log who performed the delete: console.log(..., req.body.email).

Why it failed: DELETE requests usually don't carry data in the "body" (unlike POST requests). So req.body was empty, and trying to read .email from it caused an error after the deletion had already happened.

The Fix: I changed it to read from res.locals.email. This is where our authentication middleware securely stores the logged-in user's details, so it's always available and safe to use.