### PR TITLE
fixed image not being deleted from the file directory

### DIFF
--- a/src/api/controllers/editionController.ts
+++ b/src/api/controllers/editionController.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import mongoose from "mongoose";
 import CustomError from "../../config/CustomError";
 import asyncErrorHandler from "../helpers/asyncErrorHandler";
@@ -143,6 +144,26 @@ export const deleteEdition = asyncErrorHandler(async (req, res, next) => {
   }
 
   console.log("Edition deleted", edition, "by user", req.body.email);
+
+  fs.unlink(`uploads/edition-${edition.edition_id}`, (err) => {
+    if (err) {
+      if (err.code !== "ENOENT") {
+        console.error("Deleting edition image failed", err, id);
+      }
+      return;
+    }
+    console.log("Image deleted for deleted edition");
+  });
+
+  fs.unlink(`thumbnails/edition-${edition.edition_id}_256`, (err) => {
+    if (err) {
+      if (err.code !== "ENOENT") {
+        console.error("Deleting edition thumbnail failed", err, id);
+      }
+      return;
+    }
+    console.log("Thumbnail deleted for deleted edition");
+  });
 
   res.status(StatusCode.OK).json({
     status: "success",

--- a/src/api/controllers/imageController.ts
+++ b/src/api/controllers/imageController.ts
@@ -319,7 +319,7 @@ export const delete_avatar = asyncErrorHandler(async (req, res, next) => {
   delete_image_fs(filename);
 });
 
-const delete_image_fs = (
+export const delete_image_fs = (
   filename: string,
   { only_thumbnail }: DeleteImageOptions = { only_thumbnail: false },
 ) => {


### PR DESCRIPTION

## Description



This PR ensures that when an edition is deleted, its associated cover image and thumbnail are also deleted from the filesystem storage (`uploads/` and `thumbnails/`).



### Changes



#### Backend (`nix-backend-v2`)

- **Imports**: Added `fs` module to editionController.ts

- **File Deletion**: Inside the `deleteEdition` controller, added asynchronous filesystem cleanup using `fs.unlink`:

  - Deletes original cover image at `uploads/edition-${edition.edition_id}`

  - Deletes generated cover thumbnail at `thumbnails/edition-${edition.edition_id}_256`

- **Error Handling**: Ignored `ENOENT` (file not found) errors to prevent backend failures or false logs if an edition doesn't have an associated image.



#### Frontend (`nix-frontend-v2`)

- **API Call**: Updated the `handleDelete` method in NewEdition/index.tsx to pass the deleting user's email payload (`user?.email`) to the delete request, which matches backend expectations for auditing/logging.


https://github.com/user-attachments/assets/526f9ab0-486e-4510-aecb-e29417dc8bdf






